### PR TITLE
scorpion: use own fstab

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -16,6 +16,8 @@ include device/sony/shinano/BoardConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := SGP621
 
+TARGET_RECOVERY_FSTAB = device/sony/scorpion/rootdir/fstab.shinano
+
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 12253641728
 
 #BOARD_KERNEL_CMDLINE += mem=1281M@255M mem=1407M@2048M

--- a/aosp_sgp621_common.mk
+++ b/aosp_sgp621_common.mk
@@ -15,6 +15,9 @@
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/scorpion/overlay
 
+PRODUCT_COPY_FILES += \
+    device/sony/scorpion/rootdir/fstab.shinano:root/fstab.shinano
+
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product, device/sony/shinano/device.mk)
 $(call inherit-product, vendor/sony/scorpion/scorpion-vendor.mk)

--- a/rootdir/fstab.shinano
+++ b/rootdir/fstab.shinano
@@ -1,0 +1,13 @@
+# Android fstab file
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# <src>							<mnt_point>	<type>	<mnt_flags and options>				<fs_mgr_flags>
+/dev/block/platform/msm_sdcc.1/by-name/system		/system		ext4	ro,barrier=1,discard				wait
+/dev/block/platform/msm_sdcc.1/by-name/userdata		/data		ext4	nosuid,nodev,barrier=1,noauto_da_alloc,discard	wait,check,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-name/cache		/cache		ext4	nosuid,nodev,discard				wait,check
+/dev/block/platform/msm_sdcc.1/by-name/boot		/boot		emmc	defaults					defaults
+/dev/block/platform/msm_sdcc.1/by-name/FOTAKernel	/recovery	emmc	defaults					defaults
+
+/devices/msm_sdcc.3/mmc_host*				auto		auto	defaults					voldmanaged=sdcard1:auto,noemulatedsd
+/devices/platform/xhci-hcd				auto		auto	defaults					voldmanaged=usbdisk:auto


### PR DESCRIPTION
override device/sony/scorpion/rootdir/fstab.shinano due to different mount path

aries castor castor_windy leo use: /devices/msm_sdcc.2/mmc_host for sdcard1
scorpion scorpion_windy use: /devices/msm_sdcc.3/mmc_host for sdcard1

Signed-off-by: David Viteri davidteri91@gmail.com
