### PR TITLE
scorpion: inherit dalvik definitions for tablets

### DIFF
--- a/aosp_sgp621_common.mk
+++ b/aosp_sgp621_common.mk
@@ -21,7 +21,7 @@ PRODUCT_COPY_FILES += \
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product, device/sony/shinano/device.mk)
 $(call inherit-product, vendor/sony/scorpion/scorpion-vendor.mk)
-$(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product, frameworks/native/build/tablet-7in-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 $(call inherit-product-if-exists, prebuilts/chromium/webview_prebuilt.mk)
 $(call inherit-product-if-exists, vendor/google/products/gms.mk)
@@ -70,6 +70,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_AAPT_CONFIG := large
 PRODUCT_AAPT_PREBUILT_DPI := xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
+
+PRODUCT_CHARACTERISTICS := tablet
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sf.lcd_density=320 \


### PR DESCRIPTION
Z3 tablet has 8 inc. display, inherit proper dalvik definitions https://android.googlesource.com/platform/frameworks/native/+/android-5.1.1_r24/build/tablet-7in-xhdpi-2048-dalvik-heap.mk

also set it to tablet not phone

Signed-off-by: David Viteri davidteri91@gmail.com
