### PR TITLE
scorpion: Update NFC NXP HAL naming

### DIFF
--- a/aosp_sgp621.mk
+++ b/aosp_sgp621.mk
@@ -17,6 +17,10 @@ TARGET_KERNEL_CONFIG := aosp_shinano_scorpion_defconfig
 $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)
 $(call inherit-product, device/sony/scorpion/aosp_sgp621_common.mk)
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.scorpion
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=scorpion
+
 PRODUCT_NAME := aosp_sgp621
 PRODUCT_DEVICE := scorpion
 PRODUCT_MODEL := Xperia Z3 Tablet Compact(AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives.

Signed-off-by: Humberto Borba humberos@gmail.com
